### PR TITLE
Potential fix for code scanning alert no. 14: Clear-text logging of sensitive information

### DIFF
--- a/web/tests/auth/email-password.test.ts
+++ b/web/tests/auth/email-password.test.ts
@@ -73,14 +73,14 @@ describe("Auth - Email & Password", () => {
         "NoNumbers!",
       ];
 
-      strongPasswords.forEach((password) => {
-        assert(isStrongPassword(password), `${password} should be strong`);
-        logger.log(`✓ Strong: ${password}`);
+      strongPasswords.forEach((password, idx) => {
+        assert(isStrongPassword(password), `Password[${idx}] should be strong`);
+        logger.log(`✓ Strong: [REDACTED] (index: ${idx})`);
       });
 
-      weakPasswords.forEach((password) => {
-        assert(!isStrongPassword(password), `${password} should be weak`);
-        logger.log(`✗ Weak: ${password}`);
+      weakPasswords.forEach((password, idx) => {
+        assert(!isStrongPassword(password), `Password[${idx}] should be weak`);
+        logger.log(`✗ Weak: [REDACTED] (index: ${idx})`);
       });
 
       logger.success("Password strength validation working");


### PR DESCRIPTION
Potential fix for [https://github.com/one-ie/one/security/code-scanning/14](https://github.com/one-ie/one/security/code-scanning/14)

To prevent the leakage of sensitive data via logging in tests, we should ensure that password values (even in synthetic tests) are never written to logs in cleartext. The core issue is that log messages built like `✓ Strong: ${password}` (and similar) directly interpolate sensitive strings. The fix consists of modifying the test code so that these log messages never include the password value; instead, they should indicate which item was tested ("✓ Strong password string") without revealing the actual value. Alternatively, the logger’s `log` method could specifically detect any password variable in a message and always redact it, but for clarity and simplicity, it is preferable to update the log calls in the tests themselves so that the log message does not expose the password value at all.

Changes required:
- In `web/tests/auth/email-password.test.ts`, replace log calls in password tests so they log only the password index (position) or a generic placeholder (e.g., "✓ Strong: [REDACTED]"), not the password value.
- Optionally update weak password logs similarly.

No changes are needed to the logger class or other supporting code. No additional dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
