### PR TITLE
Potential fix for code scanning alert no. 14: Clear-text logging of sensitive information

### DIFF
--- a/web/tests/auth/oauth.test.ts
+++ b/web/tests/auth/oauth.test.ts
@@ -87,7 +87,7 @@ describe("Auth - OAuth", () => {
         name: "OAuth Only User",
         providerId,
       });
-      logger.log(`OAuth user created: ${oauthResult.userId}`);
+      logger.log(`OAuth user created: [REDACTED USER ID]`);
 
       // Verify user exists and has session
       const user = await getCurrentUser(api, oauthResult.token);


### PR DESCRIPTION
Potential fix for [https://github.com/one-ie/one/security/code-scanning/14](https://github.com/one-ie/one/security/code-scanning/14)

**How to fix, in general:**  
Prevent potentially sensitive identifiers, such as user IDs, from being logged in cleartext. Either avoid logging such properties, mask/obfuscate them, or ensure sanitization logic is extended to cover these cases.

**Detailed fix for the detected problem:**  
- Update the location in `oauth.test.ts` on the line that logs `"OAuth user created: ${oauthResult.userId}"` so that it does not log the raw user ID.
- Replace the `${oauthResult.userId}` interpolation with a generic or masked representation, e.g., obfuscate most of it, or only state `"OAuth user created"` without exposing the ID.
- No change in functionality is required for the tests themselves, only the log message content needs updating.
- No new imports or class/method changes are needed; a simple string change to the log message suffices.

**Where:**  
- File: `web/tests/auth/oauth.test.ts`, line 90 (within the `"should not require password for OAuth users"` test).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
