### PR TITLE
Potential fix for code scanning alert no. 13: Clear-text logging of sensitive information

### DIFF
--- a/web/src/tests/people/auth/email-password.test.ts
+++ b/web/src/tests/people/auth/email-password.test.ts
@@ -73,14 +73,14 @@ describe("Auth - Email & Password", () => {
         "NoNumbers!",
       ];
 
-      strongPasswords.forEach((password) => {
+      strongPasswords.forEach((password, idx) => {
         assert(isStrongPassword(password), `${password} should be strong`);
-        logger.log(`✓ Strong: ${password}`);
+        logger.log(`✓ Strong password [index ${idx}] validated`);
       });
 
-      weakPasswords.forEach((password) => {
+      weakPasswords.forEach((password, idx) => {
         assert(!isStrongPassword(password), `${password} should be weak`);
-        logger.log(`✗ Weak: ${password}`);
+        logger.log(`✗ Weak password [index ${idx}] correctly rejected`);
       });
 
       logger.success("Password strength validation working");


### PR DESCRIPTION
Potential fix for [https://github.com/one-ie/one/security/code-scanning/13](https://github.com/one-ie/one/security/code-scanning/13)

To fix the problem, we need to avoid logging clear-text passwords as part of test output. This means anywhere a test password value might be passed to the logger, we should instead log something generic or redacted. For this specific case, in `web/src/tests/people/auth/email-password.test.ts`, we should change the `logger.log` calls that log passwords (in both strong and weak passwords) to avoid outputting the actual password. Instead, these log messages should state that a password was checked, without including its value, e.g., "✓ Strong password validated" or "✓ Strong password at index N", or use a placeholder such as "[REDACTED]". Only the fact that a password passed/fail the test should be output, not the password itself.  
This change should be applied to both successful and unsuccessful password checks in the "Password Requirements" test. No changes are required to the `TestLogger` implementation, only to the usage in the corresponding test file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
