### PR TITLE
Potential fix for code scanning alert no. 14: Clear-text logging of sensitive information

### DIFF
--- a/web/tests/auth/utils.ts
+++ b/web/tests/auth/utils.ts
@@ -62,12 +62,15 @@ export class TestLogger {
   }
 
   private sanitizeForLogging(message: string): string {
-    // Remove potential sensitive patterns (passwords, tokens, etc.)
+    // Remove potential sensitive patterns (passwords, tokens, user IDs, emails, etc.)
     return message
       .replace(/password[=:]\s*[^\s,}]+/gi, 'password=***')
       .replace(/token[=:]\s*[^\s,}]+/gi, 'token=***')
       .replace(/secret[=:]\s*[^\s,}]+/gi, 'secret=***')
-      .replace(/api[_-]?key[=:]\s*[^\s,}]+/gi, 'api_key=***');
+      .replace(/api[_-]?key[=:]\s*[^\s,}]+/gi, 'api_key=***')
+      .replace(/user[_-]?id[=:]?\s*[^\s,}]+/gi, 'userId=***')
+      .replace(/uid[=:]?\s*[^\s,}]+/gi, 'uid=***')
+      .replace(/email[=:]?\s*[^\s,}]+/gi, 'email=***');
   }
 
   success(message: string): void {


### PR DESCRIPTION
Potential fix for [https://github.com/one-ie/one/security/code-scanning/14](https://github.com/one-ie/one/security/code-scanning/14)

To fix this issue, we should ensure that `TestLogger.log` does not leak sensitive user identifiers. For pragmatic purposes, we should extend the sanitizer to mask not only passwords, tokens, secrets, and keys, but also values matching typical user identifiers (such as userId, uid, _id, email, etc.), at least when they appear in the message. The best approach is to add additional `replace` calls in the `sanitizeForLogging` method of `TestLogger` to redact these patterns. The change should occur exclusively in `web/tests/auth/utils.ts`. No changes are needed in the tests themselves, since the logging logic is centralized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
