### PR TITLE
Potential fix for code scanning alert no. 13: Clear-text logging of sensitive information

### DIFF
--- a/web/src/tests/people/auth/oauth.test.ts
+++ b/web/src/tests/people/auth/oauth.test.ts
@@ -87,7 +87,7 @@ describe("Auth - OAuth", () => {
         name: "OAuth Only User",
         providerId,
       });
-      logger.log(`OAuth user created: ${oauthResult.userId}`);
+      logger.log(`OAuth user created (${typeof oauthResult.userId === "string" && oauthResult.userId.length > 4 ? oauthResult.userId.slice(0, 4) + '...' : 'ID'})`);
 
       // Verify user exists and has session
       const user = await getCurrentUser(api, oauthResult.token);


### PR DESCRIPTION
Potential fix for [https://github.com/one-ie/one/security/code-scanning/13](https://github.com/one-ie/one/security/code-scanning/13)

To resolve clear-text logging of sensitive information in test logs, the best approach is to sanitize or avoid logging sensitive pieces of data like OAuth user IDs and tokens. 

**General fix:** Avoid logging raw values of sensitive fields received from authentication APIs. Instead, log non-sensitive meta-information only (such as success/failure, elapsed time, etc.), or redact/mask sensitive fields before logging.

**Concrete implementation:**  
In `web/src/tests/people/auth/oauth.test.ts`, locate any calls to `logger.log()` where the message includes sensitive fields (specifically user IDs, tokens, etc.). On line 90, change `logger.log(\`OAuth user created: ${oauthResult.userId}\`)` to redact or avoid logging the exact user ID. For example, log only a generic message like `"OAuth user created"` or, if needed for debugging, mask part of the user ID.

No changes are needed to the logger implementation in `utils.ts` because the problem is with the caller logging sensitive data, not with the logger itself.

**Files/lines changed:**  
- Only in `web/src/tests/people/auth/oauth.test.ts`, specifically line 90.

**Methods/imports/definitions needed:**  
No new methods or imports are necessary. Just update the logged string in the appropriate test case.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
